### PR TITLE
Gem does not get autoloaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ ext/**/target
 pkg/
 lib/yrb.bundle
 lib/*.*
+!lib/*.rb
 build/out
 vendor/
 target/

--- a/lib/y_rb.rb
+++ b/lib/y_rb.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require "y"


### PR DESCRIPTION
Gems that do not have a file named exactly like the gem at the lib root location, do not get autoloaded in Rails.