### PR TITLE
Second attempt to fix autoloading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "yrb"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "lib0",
  "magnus",

--- a/Rakefile
+++ b/Rakefile
@@ -46,15 +46,15 @@ namespace "gem" do
     task plat => "prepare" do
       require "rake_compiler_dock"
 
-      if plat.include?("-musl")
-        ENV["RCD_IMAGE"] = "eliias/rbsys-x86_64-linux-musl:#{RbSys::VERSION}"
-      else
-        ENV["RCD_IMAGE"] = "rbsys/#{plat}:#{RbSys::VERSION}"
-      end
+      ENV["RCD_IMAGE"] = if plat.include?("-musl")
+                           "eliias/rbsys-x86_64-linux-musl:#{RbSys::VERSION}"
+                         else
+                           "rbsys/#{plat}:#{RbSys::VERSION}"
+                         end
 
-      RakeCompilerDock.sh <<-SH, platform: plat
-          bundle && \
-          RUBY_CC_VERSION="#{cross_rubies.join(":")}" rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem
+      RakeCompilerDock.sh <<~SH, platform: plat
+        bundle && \
+        RUBY_CC_VERSION="#{cross_rubies.join(":")}" rake native:#{plat} pkg/#{spec.full_name}-#{plat}.gem
       SH
     end
   end

--- a/ext/yrb/Cargo.toml
+++ b/ext/yrb/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yrb"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Hannes Moser <box@hannesmoser.at>", "Hannes Moser <hmoser@gitlab.com>"]
 edition = "2021"
 homepage = "https://github.com/y-crdt/yrb"

--- a/lib/y-rb.rb
+++ b/lib/y-rb.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# load native extension
+begin
+  ruby_version = /(\d+\.\d+)/.match(::RUBY_VERSION)
+  require_relative "#{ruby_version}/yrb"
+rescue LoadError
+  require "yrb"
+end
+
+require_relative "y/array"
+require_relative "y/doc"
+require_relative "y/map"
+require_relative "y/text"
+require_relative "y/xml"
+require_relative "y/transaction"
+require_relative "y/version"
+
+module Y
+end

--- a/lib/y.rb
+++ b/lib/y.rb
@@ -1,20 +1,3 @@
 # frozen_string_literal: true
 
-# load native extension
-begin
-  ruby_version = /(\d+\.\d+)/.match(::RUBY_VERSION)
-  require_relative "#{ruby_version}/yrb"
-rescue LoadError
-  require "yrb"
-end
-
-require_relative "y/array"
-require_relative "y/doc"
-require_relative "y/map"
-require_relative "y/text"
-require_relative "y/xml"
-require_relative "y/transaction"
-require_relative "y/version"
-
-module Y
-end
+require_relative "y-rb"

--- a/lib/y/version.rb
+++ b/lib/y/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Y
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end

--- a/lib/y_rb.rb
+++ b/lib/y_rb.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require "y"


### PR DESCRIPTION
The previous fix used underscore instead of a dash in the file that marks the entrypoint for the library.