### PR TITLE
Add basic support for v2 encoding

### DIFF
--- a/ext/yrb/src/lib.rs
+++ b/ext/yrb/src/lib.rs
@@ -83,6 +83,8 @@ fn init() -> Result<(), Error> {
         .expect("cannot define singleton method: ydoc_new");
     ydoc.define_private_method("ydoc_encode_diff_v1", method!(YDoc::ydoc_encode_diff_v1, 2))
         .expect("cannot define private method: ydoc_encode_diff_v1");
+    ydoc.define_private_method("ydoc_encode_diff_v2", method!(YDoc::ydoc_encode_diff_v2, 2))
+        .expect("cannot define private method: ydoc_encode_diff_v2");
     ydoc.define_private_method(
         "ydoc_get_or_insert_array",
         method!(YDoc::ydoc_get_or_insert_array, 1),
@@ -156,6 +158,12 @@ fn init() -> Result<(), Error> {
         .expect("cannot define private method: ytransaction_apply_update");
     ytransaction
         .define_private_method(
+            "ytransaction_apply_update_v2",
+            method!(YTransaction::ytransaction_apply_update_v2, 1),
+        )
+        .expect("cannot define private method: ytransaction_apply_update_v2");
+    ytransaction
+        .define_private_method(
             "ytransaction_commit",
             method!(YTransaction::ytransaction_commit, 0),
         )
@@ -205,6 +213,12 @@ fn init() -> Result<(), Error> {
             method!(YTransaction::ytransaction_state_vector, 0),
         )
         .expect("cannot define private method: ytransaction_state_vector");
+    ytransaction
+        .define_private_method(
+            "ytransaction_state_vector_v2",
+            method!(YTransaction::ytransaction_state_vector_v2, 0),
+        )
+        .expect("cannot define private method: ytransaction_state_vector_v2");
 
     let ytext = module
         .define_class("Text", Default::default())

--- a/ext/yrb/src/ytransaction.rs
+++ b/ext/yrb/src/ytransaction.rs
@@ -38,6 +38,17 @@ impl YTransaction {
             .map(|u| self.transaction().as_mut().unwrap().apply_update(u))
     }
 
+    pub(crate) fn ytransaction_apply_update_v2(&self, update: Vec<u8>) -> Result<(), Error> {
+        Update::decode_v2(update.as_slice())
+            .map_err(|error| {
+                Error::new(
+                    exception::runtime_error(),
+                    format!("cannot decode update: {:?}", error),
+                )
+            })
+            .map(|u| self.transaction().as_mut().unwrap().apply_update(u))
+    }
+
     pub(crate) fn ytransaction_commit(&self) {
         self.transaction().as_mut().unwrap().commit();
     }
@@ -96,6 +107,14 @@ impl YTransaction {
             .unwrap()
             .state_vector()
             .encode_v1()
+    }
+
+    pub(crate) fn ytransaction_state_vector_v2(&self) -> Vec<u8> {
+        self.transaction()
+            .as_ref()
+            .unwrap()
+            .state_vector()
+            .encode_v2()
     }
 
     pub(crate) fn ytransaction_free(&self) {

--- a/lib/y/transaction.rb
+++ b/lib/y/transaction.rb
@@ -22,6 +22,15 @@ module Y
       ytransaction_apply_update(update)
     end
 
+    # Applies the v2 encoded update on this document. This will bring the
+    # the document to the same state as the one the update is from.
+    #
+    # @param update [::Array<Integer>]
+    # @return [void]
+    def apply_v2(update)
+      ytransaction_apply_update_v2(update)
+    end
+
     # Commits transaction
     #
     # @return [void]
@@ -89,15 +98,29 @@ module Y
       xml_text
     end
 
-    # Return state vector for transaction
+    # Return a state vector for this transaction
     #
     # @return [::Array<Integer>]
     def state
       ytransaction_state_vector
     end
 
+    # Returns a v2 state vector for this transaction
+    #
+    # @return [::Array<Integer>]
+    def state_v2
+      ytransaction_state_vector_v2
+    end
+
     # @!method ytransaction_apply_update(update)
-    #   Returns or creates an array by name
+    #   Apply the encoded update within current transaction
+    #
+    # @param update [::Array<Integer>]
+    # @return [void]
+    # @!visibility private
+
+    # @!method ytransaction_apply_update_v2(update)
+    #   Apply the v2 encoded update within current transaction
     #
     # @param update [::Array<Integer>]
     # @return [void]
@@ -154,6 +177,11 @@ module Y
     # @!visibility private
 
     # @!method ytransaction_state_vector
+    #
+    # @return [Array<Integer>]
+    # @!visibility private
+
+    # @!method ytransaction_state_vector_v2
     #
     # @return [Array<Integer>]
     # @!visibility private

--- a/spec/y/doc_spec.rb
+++ b/spec/y/doc_spec.rb
@@ -170,4 +170,20 @@ RSpec.describe Y::Doc do
       expect(count).to eq(2)
     end
   end
+
+  context "when using v2 encoding" do
+    it "encodes and restores document" do
+      local = described_class.new
+      local_text = local.get_text("my text")
+      local_text << "Hello, World!"
+
+      diff = local.diff_v2
+
+      remote = described_class.new
+      remote.sync_v2(diff)
+      remote_text = remote.get_text("my text")
+
+      expect(remote_text.to_s).to eq(local_text.to_s)
+    end
+  end
 end


### PR DESCRIPTION
Adds experimental support for the v2 encoding format. The `sync`, `diff`, `apply` methods of `Y::Doc` and `Y::Transaction` have now `v2` suffixed companions. Use them instead of the regular ones if you want to play around with `v2`.

Resolves https://github.com/y-crdt/yrb/issues/96

cc/ @jstoup111