### PR TITLE
Add Ruby 3.3 to precompiled gems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        ruby: ["3.0", "3.1", "3.2"]
+        ruby: ["3.0", "3.1", "3.2", "3.3"]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/gem.yml
+++ b/.github/workflows/gem.yml
@@ -39,7 +39,7 @@ jobs:
           platform: ${{ matrix.platform }}
           version: 'latest'
           env: |
-            RUBY_CC_VERSION=3.2.0:3.1.0:3.0.0
+            RUBY_CC_VERSION=3.3.0:3.2.0:3.1.0:3.0.0
 
       - uses: actions/download-artifact@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -273,18 +273,18 @@ dependencies = [
 
 [[package]]
 name = "rb-sys"
-version = "0.9.85"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b780e6858b0b0eced1d55d0f097c024b77a37b41f83bd35341130f78e37c51"
+checksum = "7285f2a7b92f58ab198e3fd59a71d2861478f9c4642f41e83582385818941697"
 dependencies = [
  "rb-sys-build",
 ]
 
 [[package]]
 name = "rb-sys-build"
-version = "0.9.85"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44957a3bc513dad1b0f20bdd0ee3b82e729a59da44086a6b40d8bc71958a6db8"
+checksum = "71583945f94dabb6c0dfa63f1b71e929c1901e1e288ef3739ab8bed3b7069550"
 dependencies = [
  "bindgen",
  "lazy_static",

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require "rake/testtask"
 require "rake/extensiontask"
 require "rb_sys"
 
-cross_rubies = %w[3.2.0 3.1.0 3.0.0]
+cross_rubies = %w[3.3.0 3.2.0 3.1.0 3.0.0]
 cross_platforms = %w[
   aarch64-linux
   arm64-darwin

--- a/ext/yrb/Cargo.toml
+++ b/ext/yrb/Cargo.toml
@@ -12,7 +12,7 @@ magnus = "0.6.2"
 thiserror = "1.0.56"
 yrs = "=0.16.10"
 y-sync = "=0.3.1"
-rb-sys = "0.9.85"
+rb-sys = "0.9.86"
 
 [dev-dependencies]
 magnus = { version = "0.6.2", features = ["embed"] }

--- a/y-rb.gemspec
+++ b/y-rb.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.metadata["rubygems_mfa_required"] = "true"
 
   spec.add_dependency "rake", "~> 13.0"
-  spec.add_dependency "rb_sys", "~> 0.9.71"
+  spec.add_dependency "rb_sys", "~> 0.9.86"
 
   spec.add_development_dependency "rake-compiler", "~> 1.2.1"
   spec.add_development_dependency "rake-compiler-dock", "~> 1.4.0"


### PR DESCRIPTION
To cross-compile Ruby 3.3, we need to update to rb-sys v0.9.86 (https://github.com/oxidize-rb/rb-sys/releases/tag/v0.9.86), which uses images that use rack-compiler-dock v1.4.0 (https://github.com/rake-compiler/rake-compiler-dock/releases/tag/1.4.0).