### PR TITLE
add support for xmltext diff

### DIFF
--- a/ext/yrb/src/lib.rs
+++ b/ext/yrb/src/lib.rs
@@ -489,6 +489,9 @@ fn init() -> Result<(), Error> {
         )
         .expect("cannot define private method: yxml_text_attributes");
     yxml_text
+        .define_private_method("yxml_text_diff", method!(YXmlText::yxml_text_diff, 1))
+        .expect("cannot define private method: yxml_text_diff");
+    yxml_text
         .define_private_method("yxml_text_format", method!(YXmlText::yxml_text_format, 4))
         .expect("cannot define private method: yxml_text_format");
     yxml_text

--- a/lib/y/xml.rb
+++ b/lib/y/xml.rb
@@ -526,6 +526,15 @@ module Y
       yxml_text_unobserve(subscription_id)
     end
 
+    # Diff
+    #
+    # @return[Array<YDiff>]
+    def diff
+      document.current_transaction do |tx|
+        yxml_text_diff(tx)
+      end
+    end
+
     # Format text
     #
     # @param index [Integer]
@@ -790,6 +799,12 @@ module Y
     # @!method yxml_text_attributes
     #
     # @return [Hash]
+
+    # @!method yxml_text_diff(tx)
+    #   Returns text changes as list of diffs
+    #
+    # @param transaction [Y::Transaction]
+    # @return [Array<YDiff>]
 
     # @!method yxml_text_format(tx, index, length, attrs)
     #

--- a/spec/y/xml_text_spec.rb
+++ b/spec/y/xml_text_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe Y::XMLText do
     expect(xml_text.to_s).to eq("Hello, <format>World!</format>")
   end
 
+  it "get a list of changes" do
+    doc = Y::Doc.new
+    xml_text = doc.get_xml_text("my text")
+
+    xml_text.insert(0, "Hello, World!", { format: "bold" })
+    xml_text.insert(13, " From Hannes.", { format: "italic" })
+
+    expect(xml_text.diff.map(&:to_h)).to eq([
+                                              { insert: "Hello, World!",
+                                                attrs: { "format" => "bold" } },
+                                              { insert: " From Hannes.",
+                                                attrs: { "format" => "italic" } }
+                                            ])
+  end
+
   it "inserts string at position" do
     doc = Y::Doc.new
     xml_text = doc.get_xml_text("my xml text")


### PR DESCRIPTION
Hello,

Thanks for creating and maintaining y-rb project. :clap: I've stumbled upon the same - or similar - problem as described in https://github.com/y-crdt/yrb/issues/155 - in my case however I need to serialize/deserialize from XmlText instead of YText.

Can we copy paste solution from ytext.rs to yxml_text.rs? That's what I did in this pull request. I guess it would serve my needs, although I'm not familiar with rust and yrs/yjs stuff, so... I might have mixed things up. :shrug:

What do you think?

Kind regards,
 